### PR TITLE
Create Banner component with initial styling

### DIFF
--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -1,5 +1,21 @@
+import { Box } from "@mui/material";
+
 const Banner: React.FC = () => {
-  return <div>Banner</div>;
+  return (
+    <Box
+      sx={{
+        backgroundImage:
+          "url(https://images.unsplash.com/photo-1542732351-fa2c82b0c746?q=80&w=3432&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)",
+        width: "100%",
+        height: "500px",
+        backgroundSize: "cover",
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "center bottom"
+      }}
+    >
+      Banner
+    </Box>
+  );
 };
 
 export default Banner;

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -3,8 +3,8 @@ import Banner from "../components/Banner";
 const Home: React.FC = () => {
   return (
     <div>
-      <div>Home</div>
       <Banner />
+      <div>Home</div>
     </div>
   );
 };


### PR DESCRIPTION
I updated the Banner component from div to Box (just for Atte) and gave it a background image with some sx props to make it behave a bit more nicely.

These styles are somewhat responsive, but we will optimise them more in the future. Anyway here's how it currently looks in 15" laptop view.

<img width="1680" alt="Screenshot 2024-02-27 at 14 42 22" src="https://github.com/aj-kivimaki/eurovision-data-visualizer/assets/118634468/2d344cd1-d205-4854-92e3-5adcd78ac64d">
