### PR TITLE
Refactor singlepage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
           element: <Home />,
         },
         {
-          path: "/:artistName",
+          path: "/artist/:artistName",
           element: <SinglePage />,
         },
         {

--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -10,14 +10,16 @@ interface ArtistProps {
   countryId: string;
 }
 
-const ArtistCard = ({
-  artistName,
-  artistCountry,
-  songName,
-  youtubeURL,
-  composers,
-  countryId,
-}: ArtistProps) => {
+const ArtistCard = (props: ArtistProps) => {
+  const {
+    artistName,
+    artistCountry,
+    songName,
+    youtubeURL,
+    composers,
+    countryId,
+  } = props;
+
   const videoId = youtubeURL?.split("v=")[1];
   const thumbnailAddress = `https://img.youtube.com/vi/${videoId}/0.jpg`;
   const composersProcess: string[] = composers?.split(";") ?? [];
@@ -43,7 +45,12 @@ const ArtistCard = ({
 
   const card = (
     <CardContent>
-      <Link to={artistName.toLowerCase()}>
+      <Link
+        to={{
+          pathname: `/artist/${artistName.toLowerCase()}`,
+        }}
+        state={{ props: props }}
+      >
         <CardMedia
           sx={{
             height: "200px",

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -91,6 +91,7 @@ const Home: React.FC = () => {
           >
             {artists.map((artist, index) => (
               <ArtistCard
+                {...artist}
                 key={`${artist.performer}_${index}`}
                 artistName={artist.performer}
                 artistCountry={artist.to_country}

--- a/frontend/src/routes/SinglePage.tsx
+++ b/frontend/src/routes/SinglePage.tsx
@@ -1,11 +1,12 @@
 import { Box, Typography, Button, useMediaQuery } from "@mui/material";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
-import data from "../../data/testData.json";
 import YouTube from "react-youtube";
 
 const SinglePage: React.FC = () => {
-  const artistData = data.testData[0];
+  const location = useLocation().state; //Import EurovisionData from Link element in ArtistCard
+  const artistData = location.props;
+
   const youtubeUrl = artistData.youtube_url;
   const videoId = youtubeUrl?.split("v=")[1];
   const composers: string[] = artistData.composers?.split(";") ?? [];


### PR DESCRIPTION
`SinglePage` now gets data dynamically from the database as well! I did minor refactoring on `Home`, `App`, `ArtistCard` to get things working in `SinglePage`.

<img width="1440" alt="Screenshot 2024-03-09 at 21 10 31" src="https://github.com/aj-kivimaki/eurovision-data-visualizer/assets/118634468/c904fc77-6fb2-48d8-9a42-baeb39dc731d">

- Updated paths for `SinglePage` so I could get `useLocation()` hook working. Data is passed from the `<Link>` element in `ArtistCard` with `state` prop. Then you just access it from the `SinglePage` with the `useLocation()`. This the same as we did in the Countries app in React Advanced. 
- Refactored props in `ArtistCard` for better maintainability. 
- `SinglePage` and `ArtistCard` have access to all of the data within the document they're related to. This means if we want to display some data from the document we can do that if it exists.