### PR TITLE
Styles hotfix

### DIFF
--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -44,7 +44,7 @@ const ArtistCard = (props: ArtistProps) => {
   };
 
   const card = (
-    <CardContent>
+    <CardContent sx={{p:0}}>
       <Link
         to={{
           pathname: `/artist/${artistName.toLowerCase()}`,
@@ -65,6 +65,7 @@ const ArtistCard = (props: ArtistProps) => {
           flexDirection: "column",
           gap: "0.25rem",
           mt: "1rem",
+          px:"1rem"
         }}
       >
         <Typography variant="h5" sx={{ fontWeight: "bold" }}>

--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -59,14 +59,17 @@ const ArtistCard = (props: ArtistProps) => {
           image={thumbnailAddress}
         />
       </Link>
-      <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-        <Typography variant="h4">{artistName} </Typography>
-        <img src={flagUrl} alt={artistCountry} />
+      <Box sx={{ display: "flex", flexDirection: "column", gap: "0.25rem", mt:"1rem" }}>
+        <Typography variant="h5" sx={{fontWeight:"bold"}}>{songName}</Typography>
+        <Typography variant="h6" >{artistName} </Typography>
+        <Typography sx={{ fontStyle: "italic" }}>
+          ({formatComposers(composersProcess)})
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <Typography>{artistCountry}</Typography>
+          <img src={flagUrl} alt={artistCountry} />
+        </Box>
       </Box>
-      <Typography>{songName}</Typography>
-      <Typography sx={{ fontStyle: "italic" }}>
-        ({formatComposers(composersProcess)})
-      </Typography>
     </CardContent>
   );
 

--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -23,7 +23,7 @@ const ArtistCard = (props: ArtistProps) => {
   const videoId = youtubeURL?.split("v=")[1];
   const thumbnailAddress = `https://img.youtube.com/vi/${videoId}/0.jpg`;
   const composersProcess: string[] = composers?.split(";") ?? [];
-  const flagUrl: string = `https://flagsapi.com/${countryId?.toUpperCase()}/flat/32.png`; //Docs: https://flagsapi.com/#body
+  const flagUrl: string = `https://flagsapi.com/${countryId?.toUpperCase()}/flat/24.png`; //Docs: https://flagsapi.com/#body
 
   const formatComposers = (composers: string[]): string => {
     let output = "";

--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -59,9 +59,18 @@ const ArtistCard = (props: ArtistProps) => {
           image={thumbnailAddress}
         />
       </Link>
-      <Box sx={{ display: "flex", flexDirection: "column", gap: "0.25rem", mt:"1rem" }}>
-        <Typography variant="h5" sx={{fontWeight:"bold"}}>{songName}</Typography>
-        <Typography variant="h6" >{artistName} </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.25rem",
+          mt: "1rem",
+        }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: "bold" }}>
+          {songName}
+        </Typography>
+        <Typography variant="h6">{artistName} </Typography>
         <Typography sx={{ fontStyle: "italic" }}>
           ({formatComposers(composersProcess)})
         </Typography>

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -9,6 +9,7 @@ import {
   MenuItem,
   SelectChangeEvent,
 } from "@mui/material";
+import { Link } from "react-router-dom";
 import ArtistCard from "../components/ArtistCard";
 import SearchInput from "../components/SearchInput";
 import { EurovisionData } from "../types/EurovisionModel";
@@ -72,7 +73,7 @@ const Home: React.FC = () => {
   return (
     <Box>
       <Banner />
-      <Box sx={{ backgroundColor: "primary.main", height: "500px", p: 2 }}>
+      <Box sx={{ backgroundColor: "primary.main", p: "3rem" }}>
         <Typography
           variant="h1"
           sx={{
@@ -80,10 +81,24 @@ const Home: React.FC = () => {
               xs: "2rem",
               sm: "3rem",
             },
-            textAlign: "center",
           }}
         >
           Welcome to Eurovision data visualizer app!
+        </Typography>
+        <Typography sx={{ my: "1rem" }}>
+          Explore your favorite Eurovision entries from the first Eurovision
+          Song Contest to the year 2023!
+        </Typography>
+        <Typography sx={{ my: "1rem" }}>
+          Choose a year of the contest, and then search by song, artist, or
+          country name. Click the card image for more details!
+        </Typography>
+
+        <Typography sx={{ my: "1rem" }}>
+          Delve into the rich history of the Eurovision Song Contest with our
+          interactive <Link to={"/statistics"}>statistics</Link> page. Analyze voting patterns, see
+          how countries have performed over the years, and discover fascinating
+          insights about your favorite Eurovision entries.
         </Typography>
       </Box>
       <Box sx={{ color: "#FFFFFF" }}>


### PR DESCRIPTION
# Styles Hotfix

### ArtistCard

<img width="310" alt="Screenshot 2024-03-11 at 22 52 52" src="https://github.com/aj-kivimaki/eurovision-data-visualizer/assets/118634468/a183baf4-1f0e-4e5a-8a1c-39bd9d67df8b">

- Removed that silly padding around the images 
- Adjusted country flag to match text
- Add country name on card
- Adjusted font weights to create more hierarchy

### Home

<img width="1440" alt="Screenshot 2024-03-11 at 22 54 45" src="https://github.com/aj-kivimaki/eurovision-data-visualizer/assets/118634468/48c44275-cea9-4219-b71e-e9a4ee60ad2d">

- Added descriptive text content to add hype
- Added a Link for `Statistics` page
